### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/sandyrhie/4945c810-132a-407a-8c67-098972f762d5/f0c7d73e-367d-423b-999b-a8d7e191f04c/_apis/work/boardbadge/99effb77-f0d6-40fa-a969-0969a7886e54)](https://dev.azure.com/sandyrhie/4945c810-132a-407a-8c67-098972f762d5/_boards/board/t/f0c7d73e-367d-423b-999b-a8d7e191f04c/Microsoft.RequirementCategory)
 # antibioticsTreatmentPathway
 HAP


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sandyrhie/4945c810-132a-407a-8c67-098972f762d5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.